### PR TITLE
Fix A Bunch Of Small Isssues

### DIFF
--- a/kaviyes/util/__std_util__.py
+++ b/kaviyes/util/__std_util__.py
@@ -40,7 +40,7 @@ def connected(url='http://www.google.com', timeout=5):
     '''
     try:
         response = urllib.request.urlopen(url, timeout=timeout)
-        return response.status_code == 200
+        return response.status == 200
     except urllib.error.URLError:
         return False
 

--- a/kaviyes/util/__std_util__.py
+++ b/kaviyes/util/__std_util__.py
@@ -23,7 +23,6 @@ A set of functions to streamline the development process.
 
 '''
 from os import system as _system
-from datetime import datetime as _datetime
 
 def connected(url='http://www.google.com', timeout=5):
     import urllib.request
@@ -75,7 +74,8 @@ def timenow(format: str = None, format_24H: bool = True):
     ```
     
     '''
-    now = _datetime.now()
+    from datetime import datetime
+    now = datetime.now()
 
     if format:
         return now.strftime(format)

--- a/kaviyes/util/__std_util__.py
+++ b/kaviyes/util/__std_util__.py
@@ -22,7 +22,6 @@
 A set of functions to streamline the development process.
 
 '''
-from time import sleep as _sleep
 from os import system as _system
 from datetime import datetime as _datetime
 
@@ -96,7 +95,8 @@ def delay(secs: float):
     ```
     '''
 
-    _sleep(secs)
+    from time import sleep
+    sleep(secs)
 
 def terminal(command: str):
     '''

--- a/kaviyes/util/__std_util__.py
+++ b/kaviyes/util/__std_util__.py
@@ -25,9 +25,10 @@ A set of functions to streamline the development process.
 from time import sleep as _sleep
 from os import system as _system
 from datetime import datetime as _datetime
-import requests as _requests
 
 def connected(url='http://www.google.com', timeout=5):
+    import urllib.request
+
     '''Checks if there is an active internet connection.
 
     Parameters
@@ -40,9 +41,9 @@ def connected(url='http://www.google.com', timeout=5):
     - bool: True if connected, False otherwise.
     '''
     try:
-        response = _requests.get(url, timeout=timeout)
+        response = urllib.request.urlopen(url, timeout=timeout)
         return response.status_code == 200
-    except _requests.ConnectionError:
+    except urllib.error.URLError:
         return False
 
 def reverse_string(s):

--- a/kaviyes/util/__std_util__.py
+++ b/kaviyes/util/__std_util__.py
@@ -22,8 +22,6 @@
 A set of functions to streamline the development process.
 
 '''
-from os import system as _system
-
 def connected(url='http://www.google.com', timeout=5):
     import urllib.request
 
@@ -114,9 +112,10 @@ def terminal(command: str):
     - The command will be executed in the context of the shell used by os.system, which is platform-dependent.
     - On Windows, some commands may have different syntax or requirements compared to Unix-like systems.
     '''
+    from os import system
 
     try:
-        _system(command)
+        system(command)
     except Exception as e:
         print(f"An error occured: {e}")
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setuptools.setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
     ],
-    install_requires=["requests"],
+    install_requires=[],
     python_requires='>=3.9',
 )


### PR DESCRIPTION
- We lazy load `datetime.datetime`, `time.sleep`, and `os.system` only when necessary. 
- We use `urllib.request.urlopen` instead of `requests.get` to check internet connectivity. Because `requests` is an external dependency we can avoid with ease. I also lazy load `urllib.request` only when necessary.

I have tested all my changes on my machine and they work.